### PR TITLE
Add —mnemonic flag for generate-mnemonic command

### DIFF
--- a/croncat/src/store/agent.rs
+++ b/croncat/src/store/agent.rs
@@ -140,11 +140,17 @@ impl LocalAgentStorage {
     }
 
     /// Generate a new account_id to the local storage.
-    pub fn generate_account(&mut self, account_id: AccountId) -> Result<(), Report> {
+    pub fn generate_account(&mut self, account_id: AccountId, mnemonic: Option<String>) -> Result<(), Report> {
         match self.get(&account_id) {
             Some(_) => Err(eyre!(r#"Agent "{account_id}" already created"#)),
             None => {
-                self.insert(account_id.clone(), Mnemonic::generate(24).unwrap())?;
+                let mnemonic2 = if let Some(phrase) = mnemonic {
+                    phrase
+                } else {
+                    Mnemonic::generate(24).unwrap().to_string()
+                };
+                let parsed = Mnemonic::parse_normalized(&mnemonic2);
+                self.insert(account_id.clone(), parsed.unwrap())?;
                 self.display_account(&account_id);
                 self.write_to_disk()?;
                 Ok(())

--- a/croncat/src/store/agent.rs
+++ b/croncat/src/store/agent.rs
@@ -144,13 +144,12 @@ impl LocalAgentStorage {
         match self.get(&account_id) {
             Some(_) => Err(eyre!(r#"Agent "{account_id}" already created"#)),
             None => {
-                let mnemonic2 = if let Some(phrase) = mnemonic {
-                    phrase
+                let validated_mnemonic = if let Some(phrase) = mnemonic {
+                    Mnemonic::parse_normalized(&phrase)
                 } else {
-                    Mnemonic::generate(24).unwrap().to_string()
-                };
-                let parsed = Mnemonic::parse_normalized(&mnemonic2);
-                self.insert(account_id.clone(), parsed.unwrap())?;
+                    Mnemonic::generate(24)
+                }?;
+                self.insert(account_id.clone(), validated_mnemonic)?;
                 self.display_account(&account_id);
                 self.write_to_disk()?;
                 Ok(())

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -99,7 +99,9 @@ async fn main() -> Result<(), Report> {
             let agent_tasks = querier.get_agent_tasks(account_addr).await?;
             println!("{agent_tasks}")
         }
-        opts::Command::GenerateMnemonic { new_name } => storage.generate_account(new_name)?,
+        opts::Command::GenerateMnemonic { new_name, mnemonic } => {
+            storage.generate_account(new_name, mnemonic)?
+        },
         opts::Command::UpdateAgent {
             payable_account_id,
             sender_name,
@@ -110,6 +112,7 @@ async fn main() -> Result<(), Report> {
             let log = result.log;
             println!("{log}");
         }
+        //@TODO: remember to finish this command, since it's only querying
         opts::Command::DepositUjunox { account_id } => {
             let result = deposit_junox(&account_id).await?;
             println!("{:?}", result);

--- a/croncatd/src/opts.rs
+++ b/croncatd/src/opts.rs
@@ -63,6 +63,8 @@ pub enum Command {
     GenerateMnemonic {
         #[structopt(long, default_value = "agent")]
         new_name: String,
+        #[structopt(long)]
+        mnemonic: Option<String>
     },
     DepositUjunox {
         account_id: String,

--- a/croncatd/src/opts.rs
+++ b/croncatd/src/opts.rs
@@ -63,6 +63,7 @@ pub enum Command {
     GenerateMnemonic {
         #[structopt(long, default_value = "agent")]
         new_name: String,
+        /// Recover agent from mnemonic phrase. Please do not use your own account!
         #[structopt(long)]
         mnemonic: Option<String>
     },


### PR DESCRIPTION
This allows a user to input a mnemonic instead of having one randomly generated for them.

Examples:

    cargo run generate-mnemonic --new-name new1

Creates an account named `new1` using a random mnemonic

    cargo run generate-mnemonic --mnemonic "dish hood medal observe flag reward cupboard welcome universe hover town until hidden leaf sleep park knock pumpkin silly ready gym brown hidden series" --new-name new2

Creates an account named `new2` that has the given mnemonic.

There isn't much error handling in this, but if you give an invalid BIP-30 word, for instance, the error will show: 

```
The application panicked (crashed).
Message:  called `Result::unwrap()` on an `Err` value: UnknownWord(23)
Location: croncat/src/store/agent.rs:154
```

which is pretty okay for now.