### PR TITLE
New command: `get-state`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ SUBCOMMANDS:
     get-agent            Sensitive. Shows all details about agents on this machine
     get-agent-status     Get the agent's status (pending/active)
     get-agent-tasks      Get the agent's tasks they're assigned to fulfill
+    get-state            Get contract's state
     go                   Starts the Croncat agent, allowing it to fulfill tasks
     help                 Prints this message or the help of the given subcommand(s)
     info                 Gets the configuration from the Croncat manager contract
     register-agent       Registers an agent, placing them in the pending queue unless it's the first agent
     setup-service        Setup an agent as a system service (systemd)
-    status               (in progress) Get the agent's status
     tasks                Show all task(s) information
     unregister-agent     Unregisters the agent from being in the queue with other agents
     update-agent         Update the agent's configuration

--- a/croncat/src/grpc.rs
+++ b/croncat/src/grpc.rs
@@ -8,6 +8,7 @@ use cosmrs::bip32;
 use cosmrs::crypto::secp256k1::SigningKey;
 use cosmrs::AccountId;
 use cw_croncat_core::msg::AgentTaskResponse;
+use cw_croncat_core::msg::CwCroncatResponse;
 use cw_croncat_core::msg::TaskResponse;
 use cw_croncat_core::msg::TaskWithRulesResponse;
 use cw_croncat_core::msg::{ExecuteMsg, GetConfigResponse, QueryMsg};
@@ -243,6 +244,18 @@ impl GrpcQuerier {
     pub async fn get_agent_tasks(&self, account_id: String) -> Result<String, Report> {
         let response: Option<AgentTaskResponse> = self
             .query_croncat(&QueryMsg::GetAgentTasks { account_id })
+            .await?;
+        let json = serde_json::to_string_pretty(&response)?;
+        Ok(json)
+    }
+
+    pub async fn get_contract_state(
+        &self,
+        from_index: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<String, Report> {
+        let response: CwCroncatResponse = self
+            .query_croncat(&QueryMsg::GetState { from_index, limit })
             .await?;
         let json = serde_json::to_string_pretty(&response)?;
         Ok(json)

--- a/croncatd/Cargo.toml
+++ b/croncatd/Cargo.toml
@@ -17,3 +17,6 @@ futures = "0.3"
 anyhow = "1.0.62"
 async-compat = "0.2.1"
 tokio-compat = "0.1.6"
+
+[features]
+debug = []

--- a/croncatd/Cargo.toml
+++ b/croncatd/Cargo.toml
@@ -11,7 +11,7 @@ croncat = { path = "../croncat" }
 
 reqwest = { version = "0.11.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0" 
+serde_json = "1.0"
 futures = "0.3"
 
 anyhow = "1.0.62"

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -143,7 +143,11 @@ async fn main() -> Result<(), Report> {
         opts::Command::SetupService { output } => {
             system::DaemonService::create(output, &chain_id, opts.no_frills)?;
         }
-        _ => {}
+        opts::Command::GetState { from_index, limit } => {
+            let querier = GrpcQuerier::new(cfg).await?;
+
+            querier.get_contract_state(from_index, limit).await?;
+        }
     }
 
     // Say goodbye if no no-frills

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -146,7 +146,8 @@ async fn main() -> Result<(), Report> {
         opts::Command::GetState { from_index, limit } => {
             let querier = GrpcQuerier::new(cfg).await?;
 
-            querier.get_contract_state(from_index, limit).await?;
+            let state = querier.get_contract_state(from_index, limit).await?;
+            println!("{state}");
         }
     }
 

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -143,6 +143,7 @@ async fn main() -> Result<(), Report> {
         opts::Command::SetupService { output } => {
             system::DaemonService::create(output, &chain_id, opts.no_frills)?;
         }
+        #[cfg(feature = "debug")]
         opts::Command::GetState { from_index, limit } => {
             let querier = GrpcQuerier::new(cfg).await?;
 

--- a/croncatd/src/opts.rs
+++ b/croncatd/src/opts.rs
@@ -58,6 +58,7 @@ pub enum Command {
     },
 
     /// Get contract's state
+    #[cfg(feature = "debug")]
     GetState {
         from_index: Option<u64>,
         limit: Option<u64>,

--- a/croncatd/src/opts.rs
+++ b/croncatd/src/opts.rs
@@ -57,8 +57,11 @@ pub enum Command {
         sender_name: String,
     },
 
-    /// (in progress) Get the agent's status
-    Status,
+    /// Get contract's state
+    GetState {
+        from_index: Option<u64>,
+        limit: Option<u64>,
+    },
 
     /// Show all task(s) information
     Tasks {


### PR DESCRIPTION
Closes #67

We have got new query method: `get_state`: https://github.com/CronCats/cw-croncat/pull/101

Removed `status`, since we have `get-status` command, or what's the purpose of it? @mikedotexe 
Should one return whole struct :
https://github.com/CronCats/cw-croncat/blob/4b4974f161ba616ff9656f15b4249f51bb96544d/packages/cw-croncat-core/src/types.rs#L62-L71
While the other only status? https://github.com/CronCats/cw-croncat/blob/4b4974f161ba616ff9656f15b4249f51bb96544d/packages/cw-croncat-core/src/types.rs#L65