### PR TITLE
[BUGFIX]: Save `systemd` service files into root storage directory by default.

### DIFF
--- a/croncat/src/system/service.rs
+++ b/croncat/src/system/service.rs
@@ -8,6 +8,8 @@ use color_eyre::{eyre::eyre, Report};
 use indoc::indoc;
 use tracing::log::info;
 
+use crate::store::LOCAL_STORAGE_DEFAULT_DIR;
+
 /// Name of the daemon service directory.
 const DAEMON_SERVICES_DIR_NAME: &str = "system-services";
 
@@ -17,12 +19,9 @@ pub struct DaemonService;
 impl DaemonService {
     /// Create a new daemon service file at the given path with chain ID.
     pub fn create(path: Option<String>, chain_id: &String, no_frills: bool) -> Result<(), Report> {
-        // If no path is given, use the default path
-        let default_output = std::env::current_dir()
-            .map_err(|err| eyre!("Failed to get current directory: {}", err))?
-            .to_str()
-            .unwrap()
-            .to_string();
+        // If no path is given, use the default storage path in the HOME directory.
+        let mut default_output = std::env::var("HOME").unwrap();
+        default_output.push_str(LOCAL_STORAGE_DEFAULT_DIR);
         let path = PathBuf::from(path.unwrap_or(default_output)).join(DAEMON_SERVICES_DIR_NAME);
 
         // Create the daemon service directory at the given path if it doesn't exist.


### PR DESCRIPTION
Fixes #57 