### PR TITLE
[FEATURE]: Multi-location logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "async-trait",
  "bip39",
  "chain-registry",
+ "chrono",
  "color-eyre",
  "config",
  "cosmos-sdk-proto",
@@ -682,6 +683,7 @@ dependencies = [
  "tokio-retry",
  "tonic",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
  "url",
@@ -706,6 +708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.12",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +726,15 @@ dependencies = [
  "autocfg 1.1.0",
  "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3326,6 +3347,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
+ "itoa",
  "libc",
  "num_threads",
  "time-macros",
@@ -3406,7 +3428,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.31",
 ]
 
@@ -3458,7 +3480,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "lazy_static",
  "log",
@@ -3531,7 +3553,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.31",
  "slab",
  "tokio-executor",
@@ -3654,6 +3676,17 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time 0.3.11",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/croncat/Cargo.toml
+++ b/croncat/Cargo.toml
@@ -10,6 +10,7 @@ async-channel = "1.6.1"
 async-trait = "0.1.57"
 bip39 = { version = "1.0.1", features = ["rand"] }
 chain-registry = "0.1.0"
+chrono = "0.4.19"
 color-eyre = "0.6.1"
 config = { version = "0.13.1", features = ["yaml"] }
 cosmos-sdk-proto = { version = "0.14.0", features = ["grpc", "cosmwasm"] }
@@ -36,6 +37,7 @@ tokio = { version = "1.18.0", features = ["macros", "rt-multi-thread", "signal",
 tokio-retry = "0.3.0"
 tonic = "0.8.2"
 tracing = "0.1.34"
+tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.11", features = ["fmt", "env-filter"] }
 url = "2.2.2"
 whoami = "1.2.3"

--- a/croncat/src/store/logs.rs
+++ b/croncat/src/store/logs.rs
@@ -16,7 +16,11 @@ impl ErrorLogStorage {
     fn get_path(agent_id: &String) -> PathBuf {
         let mut path = get_storage_path();
         path.push("logs");
-        path.push(format!("{}-error.log", agent_id));
+        path.push(format!(
+            "{}.error.log.{}",
+            agent_id,
+            chrono::Local::now().format("%Y-%m-%d")
+        ));
         path
     }
 

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -31,9 +31,6 @@ async fn main() -> Result<(), Report> {
     // Get environment variables
     let storage = LocalAgentStorage::new();
 
-    // Setup tracing and error reporting
-    logging::setup()?;
-
     // Get the CLI options, handle argument errors nicely
     let opts = cli::get_opts()
         .map_err(|err| {
@@ -78,7 +75,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             sender_name,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let key = storage.get_agent_signing_key(&sender_name)?;
             let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
 
@@ -96,7 +95,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             sender_name,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let key = storage.get_agent_signing_key(&sender_name)?;
             let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
             let result = signer.unregister_agent().await?;
@@ -107,7 +108,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             sender_name,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let key = storage.get_agent_signing_key(&sender_name)?;
             let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
             let result = signer.withdraw_reward().await?;
@@ -115,7 +118,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             info!("Log: {log}");
         }
         opts::Command::Info { chain_id } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
             let config = querier.query_config().await?;
             info!("Config: {config}")
@@ -124,7 +129,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             account_id,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
             let status = querier.get_agent(account_id).await?;
             info!("Agent Status: {status}")
@@ -134,7 +141,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             limit,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
             let tasks = querier.get_tasks(from_index, limit).await?;
             info!("Tasks: {tasks}")
@@ -143,7 +152,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             account_addr,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
             let agent_tasks = querier.get_agent_tasks(account_addr).await?;
             info!("Agent Tasks: {agent_tasks}")
@@ -156,7 +167,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             sender_name,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let key = storage.get_agent_signing_key(&sender_name)?;
             let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
             let result = signer.update_agent(payable_account_id).await?;
@@ -185,7 +198,9 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             with_rules,
             chain_id,
         } => {
+            let _guards = logging::setup_go(chain_id.to_string())?;
             CHAIN_ID.set(chain_id.clone()).unwrap();
+
             let key = storage.get_agent_signing_key(&sender_name)?;
             let cfg = ChainConfig::new(&chain_id).await?;
             let ChainConfig {


### PR DESCRIPTION
Resolves #79

Write logs to stdout and `~/.croncatd/logs`, here's an example `ls`:
```
➜  logs ls               
uni-5.error.log.2022-10-20  uni-5.log.2022-10-20
```