### PR TITLE
[FEATURE/REFACTOR]: Allow multiple sources in config files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "pretty_assertions",
  "rusty-fork",
  "tempfile",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -98,7 +98,7 @@ dependencies = [
  "futures-io",
  "once_cell",
  "pin-project-lite 0.2.9",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -144,7 +144,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.9",
  "rustls-native-certs 0.6.2",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-rustls 0.23.4",
  "tungstenite",
 ]
@@ -197,7 +197,7 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "serde",
  "sync_wrapper",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tower",
  "tower-http",
  "tower-layer",
@@ -661,6 +661,7 @@ dependencies = [
  "cosmos-sdk-proto",
  "cosmrs",
  "cosmwasm-std",
+ "croncat-pipeline",
  "cw-croncat-core",
  "cw-rules-core",
  "cw20 0.16.0",
@@ -678,7 +679,7 @@ dependencies = [
  "serde_json",
  "tendermint",
  "tendermint-rpc",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-retry",
  "tonic",
  "tracing",
@@ -686,6 +687,17 @@ dependencies = [
  "tracing-test",
  "url",
  "whoami",
+]
+
+[[package]]
+name = "croncat-pipeline"
+version = "0.1.0"
+source = "git+https://github.com/CronCats/croncat-pipeline#9ca8f36b28cf8bb4ca9c933c7d07c3b110132ee2"
+dependencies = [
+ "async-stream",
+ "color-eyre",
+ "futures 0.3.24",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -1380,7 +1392,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-util",
  "tracing",
 ]
@@ -1510,7 +1522,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.9",
  "socket2",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tower-service",
  "tracing",
  "want",
@@ -1529,7 +1541,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "rustls-native-certs 0.5.0",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-rustls 0.22.0",
  "tower-service",
  "webpki 0.21.4",
@@ -1547,7 +1559,7 @@ dependencies = [
  "log",
  "rustls 0.19.1",
  "rustls-native-certs 0.5.0",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-rustls 0.22.0",
  "webpki 0.21.4",
  "webpki-roots",
@@ -1561,7 +1573,7 @@ checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
  "hyper",
  "pin-project-lite 0.2.9",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-io-timeout",
 ]
 
@@ -1574,7 +1586,7 @@ dependencies = [
  "bytes 1.2.1",
  "hyper",
  "native-tls",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-native-tls",
 ]
 
@@ -2559,7 +2571,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-native-tls",
  "tower-service",
  "url",
@@ -3264,7 +3276,7 @@ dependencies = [
  "tendermint-proto",
  "thiserror",
  "time 0.3.11",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tracing",
  "url",
  "uuid",
@@ -3355,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg 1.1.0",
  "bytes 1.2.1",
@@ -3365,7 +3377,6 @@ dependencies = [
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "pin-project-lite 0.2.9",
  "signal-hook-registry",
  "socket2",
@@ -3428,7 +3439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite 0.2.9",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -3449,7 +3460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -3479,7 +3490,7 @@ checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
  "rand 0.8.5",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -3489,7 +3500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls 0.19.1",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "webpki 0.21.4",
 ]
 
@@ -3500,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls 0.20.6",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "webpki 0.22.0",
 ]
 
@@ -3512,7 +3523,7 @@ checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
- "tokio 1.21.1",
+ "tokio 1.21.2",
 ]
 
 [[package]]
@@ -3547,7 +3558,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.9",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tracing",
 ]
 
@@ -3582,7 +3593,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -3605,7 +3616,7 @@ dependencies = [
  "pin-project-lite 0.2.9",
  "rand 0.8.5",
  "slab",
- "tokio 1.21.1",
+ "tokio 1.21.2",
  "tokio-util",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "cw-rules-core",
  "cw20 0.16.0",
  "cw20-base",
+ "delegate",
  "dotenv",
  "envy",
  "futures-util",
@@ -937,6 +938,17 @@ dependencies = [
  "semver 1.0.14",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "delegate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082a24a9967533dc5d743c602157637116fc1b52806d694a5a45e6f32567fcdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/config.juno-1.yaml
+++ b/config.juno-1.yaml
@@ -1,9 +1,10 @@
 denom: "ujuno"
 prefix: "juno"
 chain_id: "juno-1"
-rpc_endpoint: "https://juno-rpc.polkachu.com:443"
 grpc_endpoint: "https://juno-grpc.polkachu.com:12690"
-wsrpc_endpoint: "wss://juno-rpc.polkachu.com/websocket"
+sources:
+    - rpc_endpoint: "https://juno-rpc.polkachu.com:443"
+      wsrpc_endpoint: "wss://juno-rpc.polkachu.com/websocket"
 contract_address: ""
 gas_prices: 0.1
 gas_adjustment: 1.5

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -1,9 +1,10 @@
 denom: "ujunox"
 prefix: "juno"
 chain_id: "testing"
-rpc_endpoint: "http://localhost:26657/"
 grpc_endpoint: "http://localhost:9090/"
-wsrpc_endpoint: "ws://localhost:26657/websocket"
+sources:
+    - rpc_endpoint: "http://localhost:26657/"
+    wsrpc_endpoint: "ws://localhost:26657/websocket"
 contract_address: null # This can be set via CRONCAT_CONTRACT_ADDRESS, committing this is a pain.
 gas_prices: 0.07
 gas_adjustment: 1.5

--- a/config.uni-5.yaml
+++ b/config.uni-5.yaml
@@ -1,9 +1,10 @@
 denom: "ujunox"
 prefix: "juno"
 chain_id: "uni-5"
-rpc_endpoint: "https://juno-testnet-rpc.polkachu.com:443"
 grpc_endpoint: "https://juno-testnet-grpc.polkachu.com:12690"
-wsrpc_endpoint: "wss://juno-testnet-rpc.polkachu.com/websocket"
+sources:
+    - rpc_endpoint: "https://juno-testnet-rpc.polkachu.com:443"
+      wsrpc_endpoint: "wss://juno-testnet-rpc.polkachu.com/websocket"
 contract_address: "juno1ntfyfpf4my6jd2ya8ypzeq94j89ejfeg45u9xrmh7u6d7excnuyskuj7cg"
 gas_prices: 0.1
 gas_adjustment: 1.5

--- a/croncat/Cargo.toml
+++ b/croncat/Cargo.toml
@@ -15,6 +15,7 @@ config = { version = "0.13.1", features = ["yaml"] }
 cosmos-sdk-proto = { version = "0.14.0", features = ["grpc", "cosmwasm"] }
 cosmrs = { version = "0.9.0", features = ["bip32", "rpc", "cosmwasm"] }
 cosmwasm-std = { version = "1.1.5" }
+croncat-pipeline = { version = "0.1.0", git = "https://github.com/CronCats/croncat-pipeline" } 
 cw-croncat-core = { version = "0.1.1" }
 cw-rules-core = { version = "0.1.0" }
 cw20 = "0.16.0"
@@ -32,7 +33,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.81"
 tendermint = "0.23.9"
 tendermint-rpc = { version = "0.23.9", features = ["websocket-client", "http-client"] }
-tokio = { version = "1.18.0", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-retry = "0.3.0"
 tonic = "0.8.2"
 tracing = "0.1.34"

--- a/croncat/Cargo.toml
+++ b/croncat/Cargo.toml
@@ -20,6 +20,7 @@ cw-croncat-core = { version = "0.1.1" }
 cw-rules-core = { version = "0.1.0" }
 cw20 = "0.16.0"
 cw20-base = "0.16.0"
+delegate = "0.8.0"
 dotenv = "0.15.0"
 envy = "0.4.2"
 futures-util = "0.3.21"

--- a/croncat/src/config/mod.rs
+++ b/croncat/src/config/mod.rs
@@ -8,12 +8,31 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChainConfigSource {
+    grpc_endpoint: String,
+    rpc_endpoint: String,
+    wsrpc_endpoint: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChainConfigFile {
+    pub denom: String,
+    pub prefix: String,
+    pub chain_id: String,
+    pub sources: Vec<ChainConfigSource>,
+    pub contract_address: Option<String>,
+    pub gas_prices: f64,
+    pub gas_adjustment: f64,
+    pub polling_duration_secs: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChainConfig {
     pub denom: String,
     pub prefix: String,
     pub chain_id: String,
-    pub rpc_endpoint: String,
     pub grpc_endpoint: String,
+    pub rpc_endpoint: String,
     pub wsrpc_endpoint: String,
     pub contract_address: Option<String>,
     pub gas_prices: f64,
@@ -22,6 +41,28 @@ pub struct ChainConfig {
 }
 
 impl ChainConfig {
+    pub fn from_chain_config_file(chain_config_file: &ChainConfigFile, source_index: u64) -> Self {
+        let source = &chain_config_file
+            .sources
+            .get(source_index as usize)
+            .ok_or_else(|| eyre!("No source found for index: {}", source_index))
+            .unwrap();
+        ChainConfig {
+            denom: chain_config_file.denom.clone(),
+            prefix: chain_config_file.prefix.clone(),
+            chain_id: chain_config_file.chain_id.clone(),
+            grpc_endpoint: source.grpc_endpoint.clone(),
+            rpc_endpoint: source.rpc_endpoint.clone(),
+            wsrpc_endpoint: source.wsrpc_endpoint.clone(),
+            contract_address: chain_config_file.contract_address.to_owned(),
+            gas_prices: chain_config_file.gas_prices,
+            gas_adjustment: chain_config_file.gas_adjustment,
+            polling_duration_secs: chain_config_file.polling_duration_secs,
+        }
+    }
+}
+
+impl ChainConfigFile {
     pub fn is_chain_registry_enabled() -> bool {
         true
     }
@@ -37,34 +78,40 @@ impl ChainConfig {
         // }
         Ok(config)
     }
+
     pub fn from_file(file_name: &str) -> Result<Self, Report> {
         let settings = Config::builder()
             .add_source(config::File::with_name(file_name))
             .build()?;
 
-        let mut config = settings.try_deserialize::<ChainConfig>()?;
+        let mut config = settings.try_deserialize::<ChainConfigFile>()?;
 
         // Override config contract address if env var is set
         if let Ok(contract_address) = std::env::var("CRONCAT_CONTRACT_ADDRESS") {
             config.contract_address = Some(contract_address);
         } else if config.contract_address.is_none() {
-            return Err(eyre!(
+            Err(eyre!(
                 "Contract address is not set via config or environment variable"
-            ));
+            ))?;
         }
 
         Ok(config)
     }
-    pub async fn from_chain_registry(fallback: ChainConfig) -> Result<Self, Report> {
-        let result = chain_registry::get::get_chain("juno").await?;
-        let apis = result.ok_or_else(|| eyre!("No chain info found"))?.apis;
 
-        let config = ChainConfig {
-            rpc_endpoint: apis.rpc[0].address.clone(),
-            grpc_endpoint: apis.grpc[0].address.clone(),
-            ..fallback
-        };
-
-        Ok(config)
+    pub fn first(&self) -> ChainConfig {
+        ChainConfig::from_chain_config_file(self, 0)
     }
+
+    // pub async fn from_chain_registry(fallback: ChainConfig) -> Result<Self, Report> {
+    //     let result = chain_registry::get::get_chain("juno").await?;
+    //     let apis = result.ok_or_else(|| eyre!("No chain info found"))?.apis;
+
+    //     let config = ChainConfig {
+    //         rpc_endpoint: apis.rpc[0].address.clone(),
+    //         grpc_endpoint: apis.grpc[0].address.clone(),
+    //         ..fallback
+    //     };
+
+    //     Ok(config)
+    // }
 }

--- a/croncat/src/config/mod.rs
+++ b/croncat/src/config/mod.rs
@@ -9,9 +9,8 @@ use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ChainConfigSource {
-    grpc_endpoint: String,
-    rpc_endpoint: String,
-    wsrpc_endpoint: String,
+    pub rpc_endpoint: String,
+    pub wsrpc_endpoint: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -20,6 +19,7 @@ pub struct ChainConfigFile {
     pub prefix: String,
     pub chain_id: String,
     pub sources: Vec<ChainConfigSource>,
+    pub grpc_endpoint: String,
     pub contract_address: Option<String>,
     pub gas_prices: f64,
     pub gas_adjustment: f64,
@@ -51,7 +51,7 @@ impl ChainConfig {
             denom: chain_config_file.denom.clone(),
             prefix: chain_config_file.prefix.clone(),
             chain_id: chain_config_file.chain_id.clone(),
-            grpc_endpoint: source.grpc_endpoint.clone(),
+            grpc_endpoint: chain_config_file.grpc_endpoint.clone(),
             rpc_endpoint: source.rpc_endpoint.clone(),
             wsrpc_endpoint: source.wsrpc_endpoint.clone(),
             contract_address: chain_config_file.contract_address.to_owned(),

--- a/croncat/src/system/mod.rs
+++ b/croncat/src/system/mod.rs
@@ -173,12 +173,12 @@ pub async fn run(
     // Create a sequencer to dedup and sort the blocks with a cache size of 32.
     let (sequencer_tx, sequencer_rx) = mpsc::unbounded_channel();
     let mut sequencer = Sequencer::new(block_stream_rx, sequencer_tx, 128)?;
-    let sequencer_handle = tokio::spawn(async move { sequencer.consume().await });
+    let _sequencer_handle = tokio::spawn(async move { sequencer.consume().await });
 
     // Dispatch the blocks to the indexer.
     let (dispatcher_tx, dispatcher_rx) = broadcast::channel(512);
     let mut dispatcher = Dispatcher::new(sequencer_rx, dispatcher_tx.clone());
-    let dispatcher_handle = tokio::spawn(async move { dispatcher.fanout().await });
+    let _dispatcher_handle = tokio::spawn(async move { dispatcher.fanout().await });
 
     // Account status checks
     let account_status_check_shutdown_rx = source_shutdown_rx.clone();
@@ -235,8 +235,6 @@ pub async fn run(
 
     // Try to join all the system tasks.
     let system_status = tokio::try_join!(
-        flatten_join(sequencer_handle),
-        flatten_join(dispatcher_handle),
         flatten_join(account_status_check_handle),
         flatten_join(task_runner_handle),
         flatten_join(rules_runner_handle),

--- a/croncat/src/system/mod.rs
+++ b/croncat/src/system/mod.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use cosmrs::bip32::{secp256k1::ecdsa::SigningKey, ExtendedPrivateKey};
 use cw_croncat_core::types::AgentStatus;
 use tokio::{sync::Mutex, task::JoinHandle};
 use tokio_retry::{
@@ -15,6 +16,7 @@ use tracing::log::error;
 
 use crate::{
     channels::{self, ShutdownRx, ShutdownTx},
+    config::{ChainConfig, ChainConfigFile},
     errors::{eyre, Report},
     grpc::GrpcSigner,
     logging::info,
@@ -33,105 +35,119 @@ pub use service::DaemonService;
 pub async fn run(
     shutdown_tx: ShutdownTx,
     shutdown_rx: ShutdownRx,
-    signer: GrpcSigner,
-    initial_status: AgentStatus,
+    key: ExtendedPrivateKey<SigningKey>,
+    config_file: &ChainConfigFile,
     with_rules: bool,
-    polling_duration_secs: u64,
 ) -> Result<(), Report> {
     // Create a block stream channel
-    let (block_stream_tx, block_stream_rx) = channels::create_block_stream(32);
+    let (block_stream_tx, _block_stream_rx) = channels::create_block_stream(32);
 
-    // Connect to GRPC  Stream new blocks from the WS RPC subscription
-    let block_stream_shutdown_rx = shutdown_rx.clone();
-    let wsrpc = signer.wsrpc().to_owned();
-    let ws_block_stream_tx = block_stream_tx.clone();
+    let source_shutdown_rx = shutdown_rx.clone();
+    for index in 0..config_file.sources.len() {
+        let cfg = ChainConfig::from_chain_config_file(config_file, index as u64);
 
-    // Generic retry strategy
-    let retry_strategy = FixedInterval::from_millis(3000).map(jitter).take(1200);
+        let signer = GrpcSigner::new(cfg.clone(), key.clone())
+            .await
+            .map_err(|err| eyre!("Failed to setup GRPC: {}", err))?;
+        let initial_status = signer
+            .get_agent(signer.account_id().as_ref())
+            .await?
+            .ok_or(eyre!("Agent must be registered to start the loop"))?
+            .status;
 
-    // Handle retries if the websocket task fails.
-    //
-    // NOTE:
-    // This was super tricky, bascially we need to pass all non Copyable values
-    // in by reference otherwise our closure will be FnOnce and we can't call it.
-    //
-    // This should be repeated for all the other tasks probably?
-    //
-    let retry_block_stream_strategy = retry_strategy.clone();
-    let retry_block_stream_handle = tokio::task::spawn(async move {
-        Retry::spawn(retry_block_stream_strategy, || async {
-            // Stream blocks
-            ws::stream_blocks_loop(&wsrpc, &ws_block_stream_tx, &block_stream_shutdown_rx)
+        // Connect to GRPC  Stream new blocks from the WS RPC subscription
+        let wsrpc = signer.wsrpc().to_owned();
+        let ws_block_stream_tx = block_stream_tx.clone();
+
+        // Generic retry strategy
+        let retry_strategy = FixedInterval::from_millis(3000).map(jitter).take(1200);
+
+        // Handle retries if the websocket task fails.
+        //
+        // NOTE:
+        // This was super tricky, basically we need to pass all non Copyable values
+        // in by reference otherwise our closure will be FnOnce and we can't call it.
+        //
+        // This should be repeated for all the other tasks probably?
+        //
+        let retry_block_stream_strategy = retry_strategy.clone();
+        let retry_block_stream_shutdown_rx = source_shutdown_rx.clone();
+        let retry_block_stream_handle = tokio::task::spawn(async move {
+            Retry::spawn(retry_block_stream_strategy, || async {
+                // Stream blocks
+                ws::stream_blocks_loop(&wsrpc, &ws_block_stream_tx, &retry_block_stream_shutdown_rx)
+                    .await
+                    .map_err(|err| {
+                        error!("Error streaming blocks: {}", err);
+                        err
+                    })
+            })
+            .await
+        });
+
+        // Set up polling
+        let block_polling_shutdown_rx = source_shutdown_rx.clone();
+        let rpc_addr = signer.rpc().to_owned();
+        let http_block_stream_tx = block_stream_tx.clone();
+
+        // Handle retries if the polling task fails.
+        let retry_polling_strategy = retry_strategy.clone();
+        let retry_polling_duration_seconds = Duration::from_secs(cfg.polling_duration_secs);
+        let retry_polling_handle = tokio::task::spawn(async move {
+            Retry::spawn(retry_polling_strategy, || async {
+                // Poll for new blocks
+                polling::poll(
+                    retry_polling_duration_seconds,
+                    &http_block_stream_tx,
+                    &block_polling_shutdown_rx,
+                    &rpc_addr,
+                )
                 .await
                 .map_err(|err| {
-                    error!("Error streaming blocks: {}", err);
+                    error!("Error polling blocks: {}", err);
                     err
                 })
-        })
-        .await
-    });
-
-    // Set up polling
-    let block_polling_shutdown_rx = shutdown_rx.clone();
-    let rpc_addr = signer.rpc().to_owned();
-    let http_block_stream_tx = block_stream_tx.clone();
-
-    // Handle retries if the polling task fails.
-    let retry_polling_strategy = retry_strategy.clone();
-    let retry_polling_handle = tokio::task::spawn(async move {
-        Retry::spawn(retry_polling_strategy, || async {
-            // Poll for new blocks
-            polling::poll(
-                Duration::from_secs(polling_duration_secs),
-                &http_block_stream_tx,
-                &block_polling_shutdown_rx,
-                &rpc_addr,
-            )
-            .await
-            .map_err(|err| {
-                error!("Error polling blocks: {}", err);
-                err
             })
-        })
-        .await
-    });
+            .await
+        });
 
-    // Account status checks
-    let account_status_check_shutdown_rx = shutdown_rx.clone();
-    let account_status_check_block_stream_rx = block_stream_rx.clone();
-    let block_status = Arc::new(Mutex::new(initial_status));
-    let block_status_accounts_loop = block_status.clone();
-    let signer_status = signer.clone();
-    let account_status_check_handle = tokio::task::spawn(agent::check_account_status_loop(
-        account_status_check_block_stream_rx,
-        account_status_check_shutdown_rx,
-        block_status_accounts_loop,
-        signer_status,
-    ));
+        // Account status checks
+        let account_status_check_shutdown_rx = source_shutdown_rx.clone();
+        let account_status_check_block_stream_rx = block_stream_rx.clone();
+        let block_status = Arc::new(Mutex::new(initial_status));
+        let block_status_accounts_loop = block_status.clone();
+        let signer_status = signer.clone();
+        let account_status_check_handle = tokio::task::spawn(agent::check_account_status_loop(
+            account_status_check_block_stream_rx,
+            account_status_check_shutdown_rx,
+            block_status_accounts_loop,
+            signer_status,
+        ));
 
-    // Process blocks coming in from the blockchain
-    let task_runner_shutdown_rx = shutdown_rx.clone();
-    let task_runner_block_stream_rx = block_stream_rx.clone();
-    let tasks_signer = signer.clone();
-    let block_status_tasks = block_status.clone();
-    let task_runner_handle = tokio::task::spawn(tasks::tasks_loop(
-        task_runner_block_stream_rx,
-        task_runner_shutdown_rx,
-        tasks_signer,
-        block_status_tasks,
-    ));
+        // Process blocks coming in from the blockchain
+        let task_runner_shutdown_rx = source_shutdown_rx.clone();
+        let task_runner_block_stream_rx = block_stream_rx.clone();
+        let tasks_signer = signer.clone();
+        let block_status_tasks = block_status.clone();
+        let task_runner_handle = tokio::task::spawn(tasks::tasks_loop(
+            task_runner_block_stream_rx,
+            task_runner_shutdown_rx,
+            tasks_signer,
+            block_status_tasks,
+        ));
 
-    // Check rules if enabled
-    let rules_runner_handle = if with_rules {
-        tokio::task::spawn(tasks::rules_loop(
-            block_stream_rx,
-            shutdown_rx,
-            signer,
-            block_status,
-        ))
-    } else {
-        tokio::task::spawn(async { Ok(()) })
-    };
+        // Check rules if enabled
+        let rules_runner_handle = if with_rules {
+            tokio::task::spawn(tasks::rules_loop(
+                block_stream_rx,
+                source_shutdown_rx,
+                signer,
+                block_status,
+            ))
+        } else {
+            tokio::task::spawn(async { Ok(()) })
+        };
+    }
 
     // Handle SIGINT AKA Ctrl-C
     let ctrl_c_shutdown_tx = shutdown_tx.clone();
@@ -150,14 +166,7 @@ pub async fn run(
     });
 
     // Try to join all the system tasks.
-    let system_status = tokio::try_join!(
-        flatten_join(ctrl_c_handle),
-        flatten_join(account_status_check_handle),
-        flatten_join(retry_block_stream_handle),
-        flatten_join(retry_polling_handle),
-        flatten_join(task_runner_handle),
-        flatten_join(rules_runner_handle),
-    );
+    let system_status = tokio::try_join!(flatten_join(ctrl_c_handle),);
 
     // If any of the tasks failed, we need to propagate the error.
     match system_status {

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -7,8 +7,8 @@ use std::process::exit;
 use croncat::{
     channels,
     //    client::{BankQueryClient, QueryBank},
-    config::{ChainConfig, ChainConfigFile},
-    errors::{eyre, Report},
+    config::ChainConfigFile,
+    errors::Report,
     grpc::{GrpcQuerier, GrpcSigner},
     logging::{self, error, info},
     store::{agent::LocalAgentStorage, logs::ErrorLogStorage},

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -7,7 +7,7 @@ use std::process::exit;
 use croncat::{
     channels,
     //    client::{BankQueryClient, QueryBank},
-    config::ChainConfig,
+    config::{ChainConfig, ChainConfigFile},
     errors::{eyre, Report},
     grpc::{GrpcQuerier, GrpcSigner},
     logging::{self, error, info},
@@ -80,7 +80,8 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
             let key = storage.get_agent_signing_key(&sender_name)?;
-            let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
+            let signer =
+                GrpcSigner::new(ChainConfigFile::new(&chain_id).await?.first(), key).await?;
 
             info!("Key: {}", signer.key().public_key().to_json());
             info!(
@@ -98,7 +99,8 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
             let key = storage.get_agent_signing_key(&sender_name)?;
-            let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
+            let signer =
+                GrpcSigner::new(ChainConfigFile::new(&chain_id).await?.first(), key).await?;
             let result = signer.unregister_agent().await?;
             let log = result.log;
             info!("Log: {log}");
@@ -109,14 +111,15 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
             let key = storage.get_agent_signing_key(&sender_name)?;
-            let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
+            let signer =
+                GrpcSigner::new(ChainConfigFile::new(&chain_id).await?.first(), key).await?;
             let result = signer.withdraw_reward().await?;
             let log = result.log;
             info!("Log: {log}");
         }
         opts::Command::Info { chain_id } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
-            let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
+            let querier = GrpcQuerier::new(ChainConfigFile::new(&chain_id).await?.first()).await?;
             let config = querier.query_config().await?;
             info!("Config: {config}")
         }
@@ -125,7 +128,7 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             chain_id,
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
-            let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
+            let querier = GrpcQuerier::new(ChainConfigFile::new(&chain_id).await?.first()).await?;
             let status = querier.get_agent(account_id).await?;
             info!("Agent Status: {status}")
         }
@@ -135,7 +138,7 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             chain_id,
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
-            let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
+            let querier = GrpcQuerier::new(ChainConfigFile::new(&chain_id).await?.first()).await?;
             let tasks = querier.get_tasks(from_index, limit).await?;
             info!("Tasks: {tasks}")
         }
@@ -144,7 +147,7 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
             chain_id,
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
-            let querier = GrpcQuerier::new(ChainConfig::new(&chain_id).await?).await?;
+            let querier = GrpcQuerier::new(ChainConfigFile::new(&chain_id).await?.first()).await?;
             let agent_tasks = querier.get_agent_tasks(account_addr).await?;
             info!("Agent Tasks: {agent_tasks}")
         }
@@ -158,7 +161,8 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
             let key = storage.get_agent_signing_key(&sender_name)?;
-            let signer = GrpcSigner::new(ChainConfig::new(&chain_id).await?, key).await?;
+            let signer =
+                GrpcSigner::new(ChainConfigFile::new(&chain_id).await?.first(), key).await?;
             let result = signer.update_agent(payable_account_id).await?;
             let log = result.log;
             info!("Log: {log}");
@@ -187,7 +191,7 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
         } => {
             CHAIN_ID.set(chain_id.clone()).unwrap();
             let key = storage.get_agent_signing_key(&sender_name)?;
-            let cfg = ChainConfig::new(&chain_id).await?;
+            let cfg = ChainConfigFile::new(&chain_id).await?;
             let ChainConfig {
                 polling_duration_secs,
                 ..


### PR DESCRIPTION
- [x] Replace the config file format that looked like this:
```yaml
denom: "ujunox"
prefix: "juno"
chain_id: "testing"
rpc_endpoint: "http://localhost:26657/"
grpc_endpoint: "http://localhost:9090/"
wsrpc_endpoint: "ws://localhost:26657/websocket"
contract_address: null # This can be set via CRONCAT_CONTRACT_ADDRESS, committing this is a pain.
gas_prices: 0.07
gas_adjustment: 1.5
polling_duration_secs: 2
```
with
```yaml
denom: "ujunox"
prefix: "juno"
chain_id: "testing"
grpc_endpoint: "http://localhost:9090/"
sources:
    - rpc_endpoint: "http://localhost:26657/"
      wsrpc_endpoint: "ws://localhost:26657/websocket"
contract_address: null # This can be set via CRONCAT_CONTRACT_ADDRESS, committing this is a pain.
gas_prices: 0.07
gas_adjustment: 1.5
polling_duration_secs: 2
```
- [x] Import `croncat-pipeline` to sequence and handle multiple sources of blocks coming in.