### PR TITLE
Allow agent to auto-withdraw rewards/balance from CronCat Manager

### DIFF
--- a/croncat/src/grpc.rs
+++ b/croncat/src/grpc.rs
@@ -49,7 +49,7 @@ pub async fn connect(url: String) -> Result<(MsgClient<Channel>, QueryClient<Cha
 
 #[derive(Clone)]
 pub struct GrpcSigner {
-    client: CosmosFullClient,
+    pub client: CosmosFullClient,
     pub account_id: AccountId,
 }
 

--- a/croncat/src/streams/agent.rs
+++ b/croncat/src/streams/agent.rs
@@ -4,7 +4,11 @@
 //!
 
 use std::sync::Arc;
-
+use cosmos_sdk_proto::cosmos::bank::v1beta1::{QueryAllBalancesRequest, QueryAllBalancesResponse};
+use prost::{DecodeError, Message};
+use tendermint::abci::Path;
+use tendermint_rpc::endpoint::abci_query::AbciQuery;
+use tendermint_rpc::{Client, HttpClient, Url};
 use color_eyre::{eyre::eyre, Report};
 use cw_croncat_core::types::AgentStatus;
 use tokio::sync::Mutex;
@@ -50,6 +54,46 @@ pub async fn check_account_status_loop(
                         .status;
                     info!("Agent status: {:?}", *locked_status);
                 }
+                
+                // Check the agent's balance to make sure it's not falling below a threshold
+                let msg_request = QueryAllBalancesRequest {
+                    address: account_addr.to_string(),
+                    pagination: None
+                };
+                println!("aloha msg_request {}", msg_request.address);
+                let encoded_msg_request = Message::encode_to_vec(&msg_request);
+
+                let rpc_address = signer.client.cfg.rpc_endpoint.clone();
+                let node_address: Url = rpc_address.parse()?;
+                let rpc_client = HttpClient::new(node_address).map_err(|err| {
+                    eyre!(
+                        "Could not get http client for RPC node for polling: {}",
+                        err.detail()
+                    )
+                })?;
+                let agent_balance: AbciQuery = rpc_client.abci_query(Some(Path::from("/cosmos.bank.v1beta1.Query/AllBalances".parse()?)), encoded_msg_request, None, false).await?;
+                let msg_response: Result<QueryAllBalancesResponse, DecodeError> =  Message::decode(&*agent_balance.value);
+                if msg_response.is_err() {
+                    // Eventually pipe a good error to whatever APM we choose
+                    println!("Error: unexpected result when querying the balance of the agent. Moving on…");
+                    continue;
+                }
+
+                let denom = signer.client.cfg.denom.clone();
+                println!("aloha denom {}", denom);
+                let agent_native_balance = msg_response
+                  .unwrap()
+                  .balances
+                  .into_iter()
+                  .find(|c| c.denom == denom)
+                  .unwrap()
+                  .amount
+                  .parse::<u128>()
+                  .unwrap();
+
+                println!("aloha agent_native_balance {}", agent_native_balance);
+                // TODO: Here's where we can use the balance to determine
+                //   if we should call withdraw_reward in grpc.rs
             }
         }
         Ok(())


### PR DESCRIPTION
This is similar to and older draft pull request here: https://github.com/CronCats/croncat-rs/pull/87

This is related to issues #84 and #85 

I'll describe what's left to do here, instead of creating a new issue))

So, as @NinoLipartiia pointed out via DMs, an agent might have a payable account different than their agent address. In this case, the objective changes a bit. Let's talk this through…

## If an agent…

### is also the payable address

It is very helpful, and arguably necessary, for the agent to automatically withdraw, which is the original intention of the issues and this pull request. We want to give the agent the ability to set a variable in the YAML files that specifies an amount of native tokens. If the agent's balance falls below that, it should automatically call `withdraw_reward` on the CronCat Manager, effectively "refilling" its native tokens and ensuring that it can continue running as an agent normally and calling `proxy_call` without the risk of running out of funds needed for the gas.

So in this case, the agent will likely choose to use some new variable (not introduced in this PR, please introduce into the YAML config(s) ) If the agent decides to _not_ add the new YAML entry, they are essentially saying, "I have another mechanism to keep my agent's balance full, don't worry about it.

### has a different payable address

In this case, the agent might desire to automatically withdraw. Or they might decide to not add the YAML variable, in which case it would never withdraw automatically.

## Summary

In both cases, we want to add a YAML variable to the config(s) that specifies a threshold (in native tokens) that, when the agent balance falls below, will trigger an automatic call to `withdraw_reward`.

If there is no YAML entry for that variable, the agent never automatically withdraws.

---

Here's the withdraw function in the CronCat Manager:
https://github.com/CronCats/cw-croncat/blob/main/contracts/cw-croncat/src/contract.rs#L157

Given the code as it is now in this draft pull request, you should be able to run this and see that the agent balance is being fetched. Look for my patented "aloha" logs here:

<img width="1311" alt="Screen Shot 2022-12-12 at 9 28 52 AM" src="https://user-images.githubusercontent.com/1042667/207134312-938dcace-79f1-4d32-99db-97bf974fa9a3.png">
