### PR TITLE
Use `cosm_orc` to get agent status using RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +301,9 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -385,6 +397,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom 7.1.3",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +447,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cosm-orc"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d7b3a13272e1fac3bea1f95bafff21f737052cbb8e47fff66550a2dc71ce63"
+dependencies = [
+ "config",
+ "cosm-tome",
+ "erased-serde",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cosm-tome"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3daaf99d2364465e81ac948e6c27ecdc63aab74ab948d9f526793009dacd9d28"
+dependencies = [
+ "async-trait",
+ "cosmrs 0.10.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tonic",
+]
+
+[[package]]
 name = "cosmos-chain-registry"
 version = "0.1.3"
 source = "git+https://github.com/CronCats/cosmos-chain-registry#e7a9875ef43eb7a40031a00ea5911a5f6582ce58"
@@ -436,7 +498,19 @@ checksum = "20b42021d8488665b1a0d9748f1f81df7235362d194f44481e2e61bf376b77b4"
 dependencies = [
  "prost",
  "prost-types",
- "tendermint-proto",
+ "tendermint-proto 0.23.9",
+ "tonic",
+]
+
+[[package]]
+name = "cosmos-sdk-proto"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673d31bd830c0772d78545de20d975129b6ab2f7db4e4e9313c3b8777d319194"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tendermint-proto 0.26.0",
  "tonic",
 ]
 
@@ -447,7 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3903590099dcf1ea580d9353034c9ba1dbf55d1389a5bd2ade98535c3445d1f9"
 dependencies = [
  "bip32",
- "cosmos-sdk-proto",
+ "cosmos-sdk-proto 0.14.0",
  "ecdsa",
  "eyre",
  "getrandom",
@@ -456,8 +530,29 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint",
- "tendermint-rpc",
+ "tendermint 0.23.9",
+ "tendermint-rpc 0.23.9",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmrs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa07096219b1817432b8f1e47c22e928c64bbfd231fc08f0a98f0e7ddd602b7"
+dependencies = [
+ "bip32",
+ "cosmos-sdk-proto 0.15.0",
+ "ecdsa",
+ "eyre",
+ "getrandom",
+ "k256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint 0.26.0",
+ "tendermint-rpc 0.26.0",
  "thiserror",
 ]
 
@@ -542,7 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "502e9052fa23805c35e2e45611985e0900a845dc7ed01ed3f5272cba58bec885"
 dependencies = [
  "chrono",
- "nom",
+ "nom 4.1.1",
  "once_cell",
 ]
 
@@ -555,9 +650,11 @@ dependencies = [
  "bip39",
  "chrono",
  "color-eyre",
+ "cosm-orc",
+ "cosm-tome",
  "cosmos-chain-registry",
- "cosmos-sdk-proto",
- "cosmrs",
+ "cosmos-sdk-proto 0.14.0",
+ "cosmrs 0.9.0",
  "cosmwasm-std",
  "croncat-pipeline",
  "cw-croncat-core",
@@ -575,8 +672,8 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "speedracer",
- "tendermint",
- "tendermint-rpc",
+ "tendermint 0.23.9",
+ "tendermint-rpc 0.23.9",
  "tokio",
  "tokio-retry",
  "tonic",
@@ -892,6 +989,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1101,15 @@ dependencies = [
  "convert_case",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1570,6 +1682,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1828,12 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1752,6 +1887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1880,6 +2025,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2051,12 @@ name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pbkdf2"
@@ -1938,6 +2099,50 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pest"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.6",
+]
 
 [[package]]
 name = "pin-project"
@@ -2234,6 +2439,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -2342,6 +2549,27 @@ dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -2924,7 +3152,38 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto",
+ "tendermint-proto 0.23.9",
+ "time 0.3.11",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa1d2d0ec1b531ba7d196f0dbee5e78ed2a82bfba928e88dff64aeec0b26073"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "ed25519",
+ "ed25519-dalek",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "ripemd160",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.26.0",
  "time 0.3.11",
  "zeroize",
 ]
@@ -2938,7 +3197,21 @@ dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.23.9",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202a2f19502c03b353d8157694ed24fbc58c3dd64a92a5b0cb80b79c82af5be4"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint 0.26.0",
  "toml",
  "url",
 ]
@@ -2948,6 +3221,24 @@ name = "tendermint-proto"
 version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ce80bf536476db81ecc9ebab834dc329c9c1509a694f211a73858814bfe023"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time 0.3.11",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "974d6330a19dfa6720e9f663fc59101d207a817db3f9c730d3f31caaa565b574"
 dependencies = [
  "bytes",
  "flex-error",
@@ -2983,9 +3274,43 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "subtle-encoding",
- "tendermint",
- "tendermint-config",
- "tendermint-proto",
+ "tendermint 0.23.9",
+ "tendermint-config 0.23.9",
+ "tendermint-proto 0.23.9",
+ "thiserror",
+ "time 0.3.11",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5d87fa5429bd2ee39c4809dd546096daf432de9b71157bc12c182ab5bae7ea7"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "flex-error",
+ "futures",
+ "getrandom",
+ "http",
+ "hyper",
+ "hyper-proxy",
+ "hyper-rustls",
+ "peg",
+ "pin-project",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle",
+ "subtle-encoding",
+ "tendermint 0.26.0",
+ "tendermint-config 0.26.0",
+ "tendermint-proto 0.26.0",
  "thiserror",
  "time 0.3.11",
  "tokio",
@@ -3422,6 +3747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,6 +4150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ chains:
         gas_adjustment: 1.3
         threshold: 1000000
     uni-5:
-        manager: juno174ncqgapq7fudqj64ut4ue47gevlqp93guecjelnkquruvnpjdgsuk046w
+        manager: juno1gqkv06dxrccavckw8ydwaxm353pvlrtx0cgxfehvn0gjvlwjfscq58nn8w
         gas_prices: 0.04
         gas_adjustment: 1.3
         threshold: 1000000

--- a/croncat/Cargo.toml
+++ b/croncat/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
+cosm-orc = "3.0.2"
+cosm-tome = "0.1.1"
 async-stream = "0.3.3"
 async-trait = "0.1.57"
 bip39 = { version = "~1.0.1", features = ["rand"] }

--- a/croncat/src/client/full_client.rs
+++ b/croncat/src/client/full_client.rs
@@ -16,7 +16,7 @@ use super::wasm_execute::{
     generate_wasm_body, prepare_send, prepare_simulate_tx, send_tx, simulate_gas_fee,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CosmosFullClient {
     pub(crate) chain_info: ChainInfo,
     pub(crate) key: bip32::XPrv,
@@ -43,7 +43,7 @@ impl CosmosFullClient {
         let service_client = ServiceClient::connect(grpc_url.clone())
             .await
             .map_err(|err| eyre!("Failed to create GRPC service client: {}", err))?;
-        let query_client = CosmosQueryClient::new(&grpc_url, &native_denom)
+        let query_client = CosmosQueryClient::new(&grpc_url, &rpc_url, &native_denom)
             .await
             .map_err(|err| eyre!("Failed to create GRPC query client: {}", err))?;
 

--- a/croncat/src/client/query_client.rs
+++ b/croncat/src/client/query_client.rs
@@ -1,6 +1,12 @@
 use color_eyre::Report;
 use serde::{de::DeserializeOwned, Serialize};
 use tonic::transport::Channel;
+use cosm_orc::orchestrator::cosm_orc::CosmOrc;
+use cosm_orc::orchestrator::deploy::DeployInfo;
+use cosm_orc::config::cfg::Config as CosmOrcConfig;
+use cosm_orc::config::ChainConfig;
+use std::collections::HashMap;
+use cosm_tome::clients::tendermint_rpc::TendermintRPC;
 
 use super::{
     auth_query::GetAuthQueryClient,
@@ -9,23 +15,46 @@ use super::{
     AuthQueryClient, WasmQueryClient,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct CosmosQueryClient {
     wasm_query_client: WasmQueryClient<Channel>,
     auth_query_client: AuthQueryClient<Channel>,
     bank_query_client: BankQueryClient,
+    tm_query_client: CosmOrc<TendermintRPC>,
 }
 
 impl CosmosQueryClient {
     pub async fn new(
         grpc: impl Into<String>,
+        rpc: impl Into<String>,
         native_denom: impl Into<String>,
     ) -> Result<Self, Report> {
         let grpc = grpc.into();
+        let rpc = rpc.into();
+        let native_denom = native_denom.into();
+        let mut contract_deploy_info = HashMap::new();
+        // TODO: remove super-hardcore-hardcoding
+        contract_deploy_info.insert("croncat-manager".to_string(), DeployInfo {
+            code_id: Some(4239),
+            address: Some("juno1gqkv06dxrccavckw8ydwaxm353pvlrtx0cgxfehvn0gjvlwjfscq58nn8w".to_string()),
+        });
+        let config = CosmOrcConfig {
+            chain_cfg: ChainConfig {
+                denom: native_denom.clone(),
+                prefix: "juno".to_string(),
+                chain_id: "uni-5".to_string(),
+                rpc_endpoint: Some(rpc.clone()),
+                grpc_endpoint: Some(grpc.clone()),
+                gas_prices: 0.025, // TODO: what is this, can turn to auto?
+                gas_adjustment: 1.3,
+            },
+            contract_deploy_info,
+        };
         Ok(Self {
             wasm_query_client: WasmQueryClient::connect(grpc.clone()).await?,
             auth_query_client: AuthQueryClient::connect(grpc.clone()).await?,
-            bank_query_client: BankQueryClient::new(grpc, native_denom.into()).await?,
+            bank_query_client: BankQueryClient::new(grpc, native_denom).await?,
+            tm_query_client: CosmOrc::new_tendermint_rpc(config, true)?
         })
     }
 
@@ -46,6 +75,10 @@ impl CosmosQueryClient {
 impl GetWasmQueryClient for CosmosQueryClient {
     fn wasm_query_client(&self) -> WasmQueryClient<Channel> {
         self.wasm_query_client.clone()
+    }
+
+    fn tm_wasm_query_client(&self) -> CosmOrc<TendermintRPC> {
+        self.tm_query_client.clone()
     }
 }
 

--- a/croncat/src/client/query_client.rs
+++ b/croncat/src/client/query_client.rs
@@ -1,12 +1,12 @@
 use color_eyre::Report;
-use serde::{de::DeserializeOwned, Serialize};
-use tonic::transport::Channel;
-use cosm_orc::orchestrator::cosm_orc::CosmOrc;
-use cosm_orc::orchestrator::deploy::DeployInfo;
 use cosm_orc::config::cfg::Config as CosmOrcConfig;
 use cosm_orc::config::ChainConfig;
-use std::collections::HashMap;
+use cosm_orc::orchestrator::cosm_orc::CosmOrc;
+use cosm_orc::orchestrator::deploy::DeployInfo;
 use cosm_tome::clients::tendermint_rpc::TendermintRPC;
+use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashMap;
+use tonic::transport::Channel;
 
 use super::{
     auth_query::GetAuthQueryClient,
@@ -34,10 +34,15 @@ impl CosmosQueryClient {
         let native_denom = native_denom.into();
         let mut contract_deploy_info = HashMap::new();
         // TODO: remove super-hardcore-hardcoding
-        contract_deploy_info.insert("croncat-manager".to_string(), DeployInfo {
-            code_id: Some(4239),
-            address: Some("juno1gqkv06dxrccavckw8ydwaxm353pvlrtx0cgxfehvn0gjvlwjfscq58nn8w".to_string()),
-        });
+        contract_deploy_info.insert(
+            "croncat-manager".to_string(),
+            DeployInfo {
+                code_id: Some(4239),
+                address: Some(
+                    "juno1gqkv06dxrccavckw8ydwaxm353pvlrtx0cgxfehvn0gjvlwjfscq58nn8w".to_string(),
+                ),
+            },
+        );
         let config = CosmOrcConfig {
             chain_cfg: ChainConfig {
                 denom: native_denom.clone(),
@@ -54,7 +59,7 @@ impl CosmosQueryClient {
             wasm_query_client: WasmQueryClient::connect(grpc.clone()).await?,
             auth_query_client: AuthQueryClient::connect(grpc.clone()).await?,
             bank_query_client: BankQueryClient::new(grpc, native_denom).await?,
-            tm_query_client: CosmOrc::new_tendermint_rpc(config, true)?
+            tm_query_client: CosmOrc::new_tendermint_rpc(config, true)?,
         })
     }
 

--- a/croncat/src/client/query_handlers/bank_query.rs
+++ b/croncat/src/client/query_handlers/bank_query.rs
@@ -5,7 +5,7 @@ use cosmos_sdk_proto::cosmos::bank::v1beta1::QueryBalanceRequest;
 use cosmos_sdk_proto::cosmos::base::v1beta1::Coin;
 use tonic::transport::Channel;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BankQueryClient {
     bank_query_client: QueryClient<Channel>,
     native_denom: String,

--- a/croncat/src/client/query_handlers/wasm_query.rs
+++ b/croncat/src/client/query_handlers/wasm_query.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use color_eyre::Report;
+use cosm_orc::orchestrator::cosm_orc::CosmOrc;
+use cosm_tome::clients::tendermint_rpc::TendermintRPC;
 use cosmos_sdk_proto::cosmwasm::wasm::v1::query_client::QueryClient;
 use cosmos_sdk_proto::cosmwasm::wasm::v1::QuerySmartContractStateRequest;
 use serde::de::DeserializeOwned;
@@ -7,6 +9,7 @@ use tonic::transport::Channel;
 
 pub trait GetWasmQueryClient {
     fn wasm_query_client(&self) -> QueryClient<Channel>;
+    fn tm_wasm_query_client(&self) -> CosmOrc<TendermintRPC>;
 }
 
 #[async_trait]

--- a/croncat/src/grpc/querier.rs
+++ b/croncat/src/grpc/querier.rs
@@ -3,17 +3,18 @@
 //!
 
 use std::time::Duration;
-
-use cw_croncat_core::msg::AgentResponse;
+use cosm_tome::modules::auth::model::Address;
 use cw_croncat_core::msg::AgentTaskResponse;
 use cw_croncat_core::msg::TaskResponse;
 use cw_croncat_core::msg::{GetConfigResponse, QueryMsg};
+use cw_croncat_core::types::AgentStatus;
 use serde::de::DeserializeOwned;
 use tokio::time::timeout;
 
 use crate::client::query_client::CosmosQueryClient;
+use crate::client::GetWasmQueryClient;
 use crate::config::ChainConfig;
-use crate::errors::Report;
+use crate::errors::{eyre, Report};
 
 pub struct GrpcQuerier {
     client: CosmosQueryClient,
@@ -29,7 +30,7 @@ impl std::fmt::Debug for GrpcQuerier {
 }
 
 impl GrpcQuerier {
-    pub async fn new(cfg: ChainConfig, grpc_url: String) -> Result<Self, Report> {
+    pub async fn new(cfg: ChainConfig, grpc_url: String, rpc_url: String) -> Result<Self, Report> {
         // TODO: How should we handle this? Is the hack okay?
         // Quick hack to add https:// to the url if it is missing
         let grpc_url = if !grpc_url.starts_with("https://") {
@@ -37,10 +38,15 @@ impl GrpcQuerier {
         } else {
             grpc_url
         };
+        let rpc_url = if !rpc_url.starts_with("https://") {
+            format!("https://{}", rpc_url)
+        } else {
+            rpc_url
+        };
 
         let client = timeout(
             Duration::from_secs(10),
-            CosmosQueryClient::new(grpc_url, &cfg.info.fees.fee_tokens[0].denom),
+            CosmosQueryClient::new(grpc_url, rpc_url, &cfg.info.fees.fee_tokens[0].denom),
         )
         .await??;
 
@@ -64,12 +70,32 @@ impl GrpcQuerier {
         Ok(json)
     }
 
-    pub async fn get_agent_status(&self, account_id: String) -> Result<String, Report> {
-        let agent: Option<AgentResponse> = self
-            .query_croncat(&QueryMsg::GetAgent { account_id })
-            .await?;
-        let json = serde_json::to_string_pretty(&agent)?;
-        Ok(json)
+    pub async fn get_agent_status(&self, account_id: String) -> Result<Option<AgentStatus>, Report> {
+        let croncat_address: Address = self.croncat_addr.parse()?;
+        let client = self.client.tm_wasm_query_client().client;
+
+        // TODO: remove this funsies block
+        'funsies_remove_me_haha: {
+            // For funsies, try it with Trevor's agent
+            let funsies = client.wasm_query(croncat_address.clone(), &QueryMsg::GetAgent { account_id: "juno1rez0cc8zx8u75wqaz04xzcr83f79lw4hk62z7t".to_string()}).await?;
+            println!("(remove this demo) funsies {:?}", funsies);
+        }
+
+        let agent = client.wasm_query(croncat_address, &QueryMsg::GetAgent { account_id }).await;
+        let agent_status_decoded = String::from_utf8(agent.unwrap().res.data.clone().unwrap());
+        let agent_status_readable = match agent_status_decoded {
+            Ok(status) => status,
+            Err(e) => return Err(eyre!("Could not turn agent status into string. {:?}", e))
+        };
+        let status: Option<AgentStatus> = match agent_status_readable.to_lowercase().as_str() {
+            "active" => Some(AgentStatus::Active),
+            "pending" => Some(AgentStatus::Pending),
+            "nominated" => Some(AgentStatus::Nominated),
+            "null" => None,
+            _ => return Err(eyre!("Unknown agent status"))
+        };
+
+        Ok(status)
     }
 
     pub async fn get_tasks(

--- a/croncat/src/grpc/service.rs
+++ b/croncat/src/grpc/service.rs
@@ -45,6 +45,7 @@ pub enum GrpcCallType {
     Query,
 }
 
+#[derive(Debug)]
 pub enum GrpcClient {
     Execute(Box<GrpcSigner>),
     Query(Box<GrpcQuerier>),
@@ -88,8 +89,8 @@ impl GrpcClientService {
             let source = source.clone();
             let chain_config = chain_config.clone();
             race_track.add_racer(name, async move {
-                let grpc_client = GrpcQuerier::new(chain_config, source.grpc.clone()).await?;
-                let _ = grpc_client.query_config().await?;
+                let rpc_client = GrpcQuerier::new(chain_config, source.grpc.clone(), source.rpc.clone()).await?;
+                let _ = rpc_client.query_config().await?;
 
                 Ok(source)
             });
@@ -100,6 +101,7 @@ impl GrpcClientService {
 
         // Get the rankings
         let rankings = race_track.rankings();
+        println!("TODO: rankings need to not disqualify if gRPC fails {:?}", rankings);
         // Get the data sources
         let data_sources = chain_config.data_sources();
 
@@ -149,7 +151,9 @@ impl GrpcClientService {
             let mut source_info = self.source_info.lock().await;
             let source_keys = source_info
                 .keys()
-                .filter(|k| !source_info.get(*k).unwrap().1)
+                .filter(|k| {
+                    !source_info.get(*k).unwrap().1
+                })
                 .collect::<Vec<_>>();
 
             if source_keys.is_empty() {
@@ -169,41 +173,48 @@ impl GrpcClientService {
             let (source, _) = source_info.get_mut(&source_key).unwrap().clone();
 
             let grpc_client = match kind {
-                GrpcCallType::Execute => GrpcClient::Execute(Box::new(
-                    match GrpcSigner::new(
-                        source.rpc.to_string(),
-                        source.grpc.to_string(),
-                        self.chain_config.info.clone(),
-                        self.chain_config.manager.clone(),
-                        self.key.clone(),
-                        self.chain_config.gas_prices,
-                        self.chain_config.gas_adjustment,
-                    )
-                    .await
-                    {
-                        Ok(client) => client,
-                        Err(e) => {
-                            debug!("Failed to create grpc client for {}: {}", source_key, e);
-                            let (_, bad) = source_info.get_mut(&source_key).unwrap();
-                            *bad = true;
-                            last_error = Some(e);
-                            continue;
-                        }
-                    },
-                )),
-                GrpcCallType::Query => GrpcClient::Query(Box::new(
-                    match GrpcQuerier::new(self.chain_config.clone(), source.grpc.to_string()).await
-                    {
-                        Ok(client) => client,
-                        Err(e) => {
-                            debug!("Failed to create grpc client for {}: {}", source_key, e);
-                            let (_, bad) = source_info.get_mut(&source_key).unwrap();
-                            *bad = true;
-                            last_error = Some(e);
-                            continue;
-                        }
-                    },
-                )),
+                GrpcCallType::Execute => {
+                    GrpcClient::Execute(Box::new(
+                        match GrpcSigner::new(
+                            source.rpc.to_string(),
+                            source.grpc.to_string(),
+                            self.chain_config.info.clone(),
+                            self.chain_config.manager.clone(),
+                            self.key.clone(),
+                            self.chain_config.gas_prices,
+                            self.chain_config.gas_adjustment,
+                        )
+                          .await
+                        {
+                            Ok(client) => client,
+                            Err(e) => {
+                                debug!("Failed to create grpc client for {}: {}", source_key, e);
+                                let (_, bad) = source_info.get_mut(&source_key).unwrap();
+                                *bad = true;
+                                last_error = Some(e);
+                                continue;
+                            }
+                        },
+                    ))
+                },
+                GrpcCallType::Query => {
+                    GrpcClient::Query(Box::new(
+                        match GrpcQuerier::new(self.chain_config.clone(), source.grpc.to_string(), "https://juno-testnet-rpc.polkachu.com:443".to_string()).await
+                        // match GrpcQuerier::new(self.chain_config.clone(), source.grpc.to_string(), source.rpc.to_string()).await
+                        {
+                            Ok(client) => {
+                                client
+                            },
+                            Err(e) => {
+                                debug!("Failed to create grpc client for {}: {}", source_key, e);
+                                let (_, bad) = source_info.get_mut(&source_key).unwrap();
+                                *bad = true;
+                                last_error = Some(e);
+                                continue;
+                            }
+                        },
+                    ))
+                },
             };
 
             match f(grpc_client).await {

--- a/croncat/src/grpc/signer.rs
+++ b/croncat/src/grpc/signer.rs
@@ -25,7 +25,7 @@ use crate::client::QueryBank;
 use crate::config::ChainConfig;
 use crate::errors::{eyre, Report};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GrpcSigner {
     client: CosmosFullClient,
     pub manager: String,

--- a/croncat/src/system/mod.rs
+++ b/croncat/src/system/mod.rs
@@ -54,7 +54,7 @@ pub async fn run(
         .await?;
 
     if raw_status.is_none() {
-        return Err(eyre!("Agent is not registered"))
+        return Err(eyre!("Agent is not registered"));
     }
 
     let account_id = client.account_id();

--- a/croncat/src/system/mod.rs
+++ b/croncat/src/system/mod.rs
@@ -43,21 +43,22 @@ pub async fn run(
 
     // Get the status of the agent
     let account_id = client.account_id();
-    let status = client
-        .execute(move |signer| {
+    let raw_status = client
+        .query(move |querier| {
             let account_id = account_id.clone();
             async move {
-                signer
-                    .get_agent(&account_id)
-                    .await
-                    .map_err(|err| eyre!("Failed to get agent status: {}", err))?
-                    .ok_or_else(|| eyre!("Agent account {} is not registered", account_id))
-                    .map(|agent| agent.status)
+                let agent_status = querier.get_agent_status(account_id).await;
+                agent_status
             }
         })
         .await?;
 
+    if raw_status.is_none() {
+        return Err(eyre!("Agent is not registered"))
+    }
+
     let account_id = client.account_id();
+    let status = raw_status.unwrap(); // We know we can
     info!("[{}] Agent account id: {}", chain_id, account_id);
     info!("[{}] Initial agent status: {:?}", chain_id, status);
     let status = Arc::new(Mutex::new(status));

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -262,7 +262,10 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
                         // Handle the result of the query
                         match query {
                             Ok(result) => {
-                                info!("Result: {}", result);
+                                match result {
+                                    None => info!("Agent is not registered…"),
+                                    Some(status) => info!("Status Result: {:?}", status)
+                                }
                             }
                             Err(err) if err.to_string().contains("Agent not registered") => {
                                 Err(eyre!("Agent not registered"))?;

--- a/croncatd/src/main.rs
+++ b/croncatd/src/main.rs
@@ -261,12 +261,10 @@ async fn run_command(opts: Opts, mut storage: LocalAgentStorage) -> Result<(), R
 
                         // Handle the result of the query
                         match query {
-                            Ok(result) => {
-                                match result {
-                                    None => info!("Agent is not registered…"),
-                                    Some(status) => info!("Status Result: {:?}", status)
-                                }
-                            }
+                            Ok(result) => match result {
+                                None => info!("Agent is not registered…"),
+                                Some(status) => info!("Status Result: {:?}", status),
+                            },
                             Err(err) if err.to_string().contains("Agent not registered") => {
                                 Err(eyre!("Agent not registered"))?;
                             }


### PR DESCRIPTION
This is the first step towards removing all queries to the CronCat manager contract that use gRPC.

Seeing as finding and setting up a gRPC node is difficult, and since we don't need gRPC signing for queries, this example will hopefully help us move away from gRPC entirely. 

We can keep the code that sets up gRPC but let's not require it, and this means the "race" that happens to determine if connections work can be removed.

You can see from the `funsies_remove_me_haha` block that you can toy around and see the queries working.